### PR TITLE
fix renderflow exception

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -126,6 +126,7 @@ class MyHomePageState extends State<MyHomePage>
             left: 0,
             right: 0,
             child: Container(
+              alignment: Alignment.bottomCenter,
               decoration: BoxDecoration(
                   shape: BoxShape.circle,
                   border: Border.all(color: Colors.red, width: 4.0)),
@@ -159,9 +160,9 @@ class MyHomePageState extends State<MyHomePage>
 class MonthlyStatusListing extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 32.0),
-      child: Row(
+    return Flexible(
+      child:
+      Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         mainAxisSize: MainAxisSize.max,
         children: <Widget>[


### PR DESCRIPTION
@PrateekSharma1712 Nice UI and implementation. I observed a renderflow exception at the bottom of the screen on both platforms, as below:

Android (Nexus 6P emulator):

![screen shot 2019-01-12 at 10 15 30 pm](https://user-images.githubusercontent.com/16548367/51076342-5445c780-16bd-11e9-92d3-ae9b8ce5e7ef.png)

iOS (iphone 8 - 11.4):

![screen shot 2019-01-12 at 10 15 41 pm](https://user-images.githubusercontent.com/16548367/51076353-63c51080-16bd-11e9-922d-34a191e8df2d.png)

The issue was: You had `MonthlyStatusRow` and `MonthlyTargetRow` inside `Padding` widget which had `column` as children which tend to take maximum space. Instead, I wrapped above widgets inside `Flexible` widget which assigns applicable space to the columns.

Now, the widgets are rendered correctly:

![screen shot 2019-01-12 at 10 50 19 pm](https://user-images.githubusercontent.com/16548367/51076394-ecdc4780-16bd-11e9-83c3-a83436ce0b5d.png)
![screen shot 2019-01-12 at 10 51 42 pm](https://user-images.githubusercontent.com/16548367/51076395-ed74de00-16bd-11e9-8e3c-38d9ad9e637a.png)

Let me know if you have any questions. Feedback / suggestions are welcome.


